### PR TITLE
Build-depend on libssl-dev and extract the libssl package name at bui…

### DIFF
--- a/packages/cl+ssl/debian/changelog
+++ b/packages/cl+ssl/debian/changelog
@@ -1,3 +1,10 @@
+cl-plus-ssl (20150608-3) UNRELEASED; urgency=medium
+
+  * Build-depend on libssl-dev and extract the libssl package name at
+    build-time instead of hardcoding it.
+
+ -- Christoph Berg <myon@debian.org>  Sun, 17 Jan 2016 16:30:25 +0100
+
 cl-plus-ssl (20150608-2) unstable; urgency=medium
 
   * Switch to depend on libssl1.0.2, (Closes: Bug#804324)

--- a/packages/cl+ssl/debian/control
+++ b/packages/cl+ssl/debian/control
@@ -3,7 +3,7 @@ Section: lisp
 Priority: optional
 Maintainer: Dimitri Fontaine <dim@tapoueh.org>
 Build-Depends: debhelper (>= 7)
-Build-Depends-Indep: dh-lisp
+Build-Depends-Indep: dh-lisp, libssl-dev
 Standards-Version: 3.9.6
 Homepage: http://common-lisp.net/project/cl-plus-ssl/
 Vcs-Git: https://github.com/cl-plus-ssl/cl-plus-ssl.git
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/cl-plus-ssl/cl-plus-ssl
 
 Package: cl-plus-ssl
 Architecture: all
-Depends: ${misc:Depends}, cl-cffi, cl-trivial-gray-streams, cl-flexi-streams, cl-bordeaux-threads, cl-trivial-garbage, libssl1.0.2
+Depends: ${misc:Depends}, cl-cffi, cl-trivial-gray-streams, cl-flexi-streams, cl-bordeaux-threads, cl-trivial-garbage, ${ssl:Depends}
 Description: Common Lisp interface to OpenSSL
  CL+SSL is portable code based on CFFI and gray streams. It defines its own
  libssl BIO method, so that SSL I/O can be written over portable Lisp

--- a/packages/cl+ssl/debian/rules
+++ b/packages/cl+ssl/debian/rules
@@ -5,6 +5,8 @@ clc-source	:= usr/share/common-lisp/source
 clc-systems	:= usr/share/common-lisp/systems
 clc-files	:= $(clc-source)/$(pkg)
 
+LIBSSL		:= $(shell dpkg-query --showformat='$${Depends}' --show libssl-dev | grep -o 'libssl[^ ]*')
+
 %:
 	dh $@ --with lisp
 
@@ -17,3 +19,7 @@ override_dh_link:
 
 override_dh_installdocs:
 	dh_installdocs index.html index.css
+
+override_dh_gencontrol:
+	echo "ssl:Depends=$(LIBSSL)" >> debian/cl-plus-ssl.substvars
+	dh_gencontrol


### PR DESCRIPTION
…ld-time instead of hardcoding it.

This fixes the currently broken dependency of cl-plus-ssl to libssl1.0.2 on
wheezy on apt.postgresql.org, and will avoid problems with future SONAME
changes of libssl in Debian sid.
