### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/packages/cl-containers/debian/changelog
+++ b/packages/cl-containers/debian/changelog
@@ -1,3 +1,10 @@
+cl-containers (20170403-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since stretch:
+    + Build-Depends: Drop versioned constraint on debhelper.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Mon, 16 Nov 2020 10:39:14 -0000
+
 cl-containers (20170403-1) unstable; urgency=medium
 
   * Quicklisp release update.

--- a/packages/cl-containers/debian/control
+++ b/packages/cl-containers/debian/control
@@ -2,7 +2,7 @@ Source: cl-containers
 Section: lisp
 Priority: optional
 Maintainer: Dimitri Fontaine <dim@tapoueh.org>
-Build-Depends: debhelper (>= 7)
+Build-Depends: debhelper
 Build-Depends-Indep: dh-lisp
 Standards-Version: 3.9.6
 Homepage: http://common-lisp.net/project/cl-containers/


### PR DESCRIPTION
Remove unnecessary constraints.

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/cl-containers/e9bfa777-f31c-449c-93dc-3e29057e1e0e.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/e9bfa777-f31c-449c-93dc-3e29057e1e0e/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/e9bfa777-f31c-449c-93dc-3e29057e1e0e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/e9bfa777-f31c-449c-93dc-3e29057e1e0e/diffoscope)).
