### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/packages/cl-db3/debian/control
+++ b/packages/cl-db3/debian/control
@@ -12,5 +12,6 @@ Vcs-Browser: https://github.com/dimitri/ql-to-deb/tree/master/packages/cl-db3
 Package: cl-db3
 Architecture: all
 Depends: ${misc:Depends}
+Multi-Arch: foreign
 Description: Common Lisp lib to read dbf files version 3
  Allows processing data found in dbf and db3 files.


### PR DESCRIPTION


Apply hints suggested by the multi-arch hinter.



These changes were suggested on https://wiki.debian.org/MultiArch/Hints.

Note that in some cases, these multi-arch hints may trigger lintian warnings
until the dependencies of the package support multi-arch. This is expected,
see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.



This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/cl-db3/605ffa9d-6a6c-4212-bae6-b762b1569286.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/605ffa9d-6a6c-4212-bae6-b762b1569286/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/605ffa9d-6a6c-4212-bae6-b762b1569286/diffoscope)).
