### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/packages/cl-db3/debian/changelog
+++ b/packages/cl-db3/debian/changelog
@@ -1,3 +1,9 @@
+cl-db3 (20200212-2) UNRELEASED; urgency=medium
+
+  * Use secure copyright file specification URI.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 05 Jan 2023 06:38:01 -0000
+
 cl-db3 (20200212-1) unstable; urgency=medium
 
   * Team upload.

--- a/packages/cl-db3/debian/changelog
+++ b/packages/cl-db3/debian/changelog
@@ -1,6 +1,7 @@
 cl-db3 (20200212-2) UNRELEASED; urgency=medium
 
   * Use secure copyright file specification URI.
+  * Set upstream metadata fields: Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 05 Jan 2023 06:38:01 -0000
 

--- a/packages/cl-db3/debian/changelog
+++ b/packages/cl-db3/debian/changelog
@@ -2,6 +2,7 @@ cl-db3 (20200212-2) UNRELEASED; urgency=medium
 
   * Use secure copyright file specification URI.
   * Set upstream metadata fields: Repository-Browse.
+  * Use canonical URL in Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 05 Jan 2023 06:38:01 -0000
 

--- a/packages/cl-db3/debian/changelog
+++ b/packages/cl-db3/debian/changelog
@@ -3,6 +3,7 @@ cl-db3 (20200212-2) UNRELEASED; urgency=medium
   * Use secure copyright file specification URI.
   * Set upstream metadata fields: Repository-Browse.
   * Use canonical URL in Vcs-Git.
+  * Update standards version to 4.6.2, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 05 Jan 2023 06:38:01 -0000
 

--- a/packages/cl-db3/debian/control
+++ b/packages/cl-db3/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Dimitri Fontaine <dim@tapoueh.org>
 Build-Depends: debhelper-compat (= 13)
 Build-Depends-Indep: dh-lisp
-Standards-Version: 4.5.0
+Standards-Version: 4.6.2
 Homepage: https://github.com/dimitri/cl-db3
 Vcs-Git: https://github.com/dimitri/ql-to-deb.git [packages/cl-db3]
 Vcs-Browser: https://github.com/dimitri/ql-to-deb/tree/master/packages/cl-db3

--- a/packages/cl-db3/debian/control
+++ b/packages/cl-db3/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper-compat (= 13)
 Build-Depends-Indep: dh-lisp
 Standards-Version: 4.5.0
 Homepage: https://github.com/dimitri/cl-db3
-Vcs-Git: https://github.com/dimitri/ql-to-deb [packages/cl-db3]
+Vcs-Git: https://github.com/dimitri/ql-to-deb.git [packages/cl-db3]
 Vcs-Browser: https://github.com/dimitri/ql-to-deb/tree/master/packages/cl-db3
 
 Package: cl-db3

--- a/packages/cl-db3/debian/copyright
+++ b/packages/cl-db3/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: cl-abnf
 Upstream-Contact: Dimitri Fontaine <dim@tapoueh.org>
 Source: https://github.com/dimitri/cl-abnf

--- a/packages/cl-db3/debian/upstream/metadata
+++ b/packages/cl-db3/debian/upstream/metadata
@@ -1,0 +1,2 @@
+---
+Repository-Browse: https://github.com/dimitri/cl-abnf


### PR DESCRIPTION
Fix some issues reported by lintian

* Use secure copyright file specification URI. ([insecure-copyright-format-uri](https://lintian.debian.org/tags/insecure-copyright-format-uri))
* Set upstream metadata fields: Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing))
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/fccb918c-1b13-4232-bc72-1aaedbc2937b/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/fccb918c-1b13-4232-bc72-1aaedbc2937b/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/fccb918c-1b13-4232-bc72-1aaedbc2937b/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/cl-db3/fccb918c-1b13-4232-bc72-1aaedbc2937b.