### PR TITLE
Fix for Dockerfile smell DL4000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:unstable
-MAINTAINER Dimitri Fontaine <dim@tapoueh.org>
+LABEL maintainer="Dimitri Fontaine <dim@tapoueh.org>"
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends          \


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL4000 occurs when the deprecated MAINTAINER instruction is used.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, the MAINTAINER instruction is replaced by an equivalent LABEL instruction as recommended by the official guidelines.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance